### PR TITLE
Fix l10n_ch_delivery_carrier_label_quickpack notification

### DIFF
--- a/l10n_ch_delivery_carrier_label_quickpac/quickpac/web_service.py
+++ b/l10n_ch_delivery_carrier_label_quickpac/quickpac/web_service.py
@@ -361,14 +361,18 @@ class QuickpacWebService(object):
         :return: Notification
         """
         communication = Communication(
-            email=picking.partner_id.email,
-            mobile=picking.partner_id.mobile
+            email=picking.partner_id.email or None,
+            mobile=(
+                picking.partner_id.mobile or
+                picking.partner_id.phone or
+                None
+            )
         )
         notification = Notification(
             communication=communication,
             service="441",
             language=get_language(picking.partner_id.lang),
-            type="EMAIL",
+            type=1 if communication.mobile else 0, 
         )
         return notification
 


### PR DESCRIPTION
Empty email or phone must return null value
![image](https://user-images.githubusercontent.com/67733397/163327927-75366665-4e2e-4c7d-aa8f-3fc515b0c25f.png)
